### PR TITLE
Add scroll-triggered animations

### DIFF
--- a/scrollAnimations.js
+++ b/scrollAnimations.js
@@ -1,0 +1,55 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const hud = document.getElementById('phase-hud');
+  const sections = document.querySelectorAll('section[id^="phase"]');
+
+  const fragments = [
+    '⊘ Source spark',
+    '✶ Light fracture',
+    '∞ Rhythm echo',
+    '⬣ Darkness fold',
+    '⧗ Reflection pause',
+    '⋰ Endurance rise',
+    '▦ Order imprint',
+    '✧ Separation veil',
+    '⟡ Conscience flare',
+    '✵ Threshold breach',
+    '★ Resurrection return'
+  ];
+
+  sections.forEach((section, idx) => {
+    const frag = document.createElement('div');
+    frag.className = 'fragment reveal';
+    frag.textContent = fragments[idx] || '';
+    section.appendChild(frag);
+
+    const particles = document.createElement('div');
+    particles.className = 'particles reveal';
+    for (let i = 0; i < 6; i++) {
+      const span = document.createElement('span');
+      span.className = 'particle';
+      span.style.left = Math.random() * 100 + '%';
+      span.style.animationDelay = (Math.random() * 2) + 's';
+      particles.appendChild(span);
+    }
+    section.appendChild(particles);
+  });
+
+  let active = null;
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.intersectionRatio >= 0.5) {
+        active = entry.target;
+        entry.target.classList.add('in-view');
+        const title = entry.target.querySelector('h1');
+        if (title) {
+          hud.textContent = title.textContent.trim();
+          hud.classList.add('show');
+        }
+      } else if (active === entry.target) {
+        hud.classList.remove('show');
+      }
+    });
+  }, { threshold: 0.5 });
+
+  sections.forEach(section => observer.observe(section));
+});

--- a/spiral.html
+++ b/spiral.html
@@ -212,6 +212,48 @@
         display: none;
       }
     }
+    section[id^="phase"] {
+      position: relative;
+    }
+
+    .reveal {
+      opacity: 0;
+      transform: translateY(20px);
+      transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+    }
+
+    section[id^="phase"].in-view .reveal {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .particles {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      overflow: hidden;
+    }
+
+    .particle {
+      position: absolute;
+      bottom: 0;
+      width: 4px;
+      height: 4px;
+      background: rgba(255, 255, 255, 0.8);
+      border-radius: 50%;
+      opacity: 0;
+      animation: rise 4s linear infinite;
+    }
+
+    @keyframes rise {
+      from { transform: translateY(0); opacity: 0; }
+      20% { opacity: 0.8; }
+      to { transform: translateY(-80px); opacity: 0; }
+    }
+
 
 
 
@@ -547,29 +589,7 @@
 </section>
 
 
-    <script>
-      document.addEventListener('DOMContentLoaded', function () {
-        const hud = document.getElementById('phase-hud');
-        const sections = document.querySelectorAll('section[id^="phase"]');
-        let active = null;
-        const observer = new IntersectionObserver((entries) => {
-          entries.forEach((entry) => {
-            if (entry.intersectionRatio >= 0.5) {
-              active = entry.target;
-              const title = entry.target.querySelector('h1');
-              if (title) {
-                hud.textContent = title.textContent.trim();
-                hud.classList.add('show');
-              }
-            } else if (active === entry.target) {
-              hud.classList.remove('show');
-            }
-          });
-        }, { threshold: 0.5 });
-
-        sections.forEach(section => observer.observe(section));
-      });
-    </script>
+  <script src="scrollAnimations.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement IntersectionObserver-powered animations in `scrollAnimations.js`
- animate phase sections with glyph fragments and particles on scroll
- expose CSS classes for `.reveal` elements
- load new script in `spiral.html` and remove old inline script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845c9697b7083249d60cff0eae85b8d